### PR TITLE
Fix blocks not refreshing in singleplayer.

### DIFF
--- a/src/main/java/ghostwolf/simplyloaders/tileentities/TileEntityLoaderBase.java
+++ b/src/main/java/ghostwolf/simplyloaders/tileentities/TileEntityLoaderBase.java
@@ -287,6 +287,7 @@ public class TileEntityLoaderBase extends TileEntity implements ICapabilityProvi
 	    public void handleUpdateTag(NBTTagCompound tag) {
 	    	readFromNBT(tag);
 	    	setBlockState();
+	        world.markBlockRangeForRenderUpdate(pos, pos);
 	    }
 	    
 	    @Override


### PR DESCRIPTION
This is pretty much an implementation of the second point in https://www.reddit.com/r/feedthebeast/comments/6e6k4s/any_good_guides_on_how_to_change_blockstates_and/di90ycw/

You might want to do this yourself as I've used spaces instead of tabs here.

I've noticed a few things that you do manually but vanilla minecraft provides for you - for example ````TileEntityLoaderBase.getChest()```` does the block position offset manually - however you could replace all of the if statements with a call to ````pos.offset(inputSide)````.